### PR TITLE
Docs: explicit DeriveAnyClass strategy for barbies

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -27,6 +27,7 @@ extensions and add some imports:
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
@@ -172,7 +173,8 @@ data FlatConfigB f = FlatConfigB
     _fcDirB :: f String,
     _fcLogB :: f Bool
   }
-  deriving (Generic, B.FunctorB, B.TraversableB, B.ApplicativeB)
+  deriving stock Generic
+  deriving anyclass (B.FunctorB, B.TraversableB, B.ApplicativeB)
 ```
 
 I also derived some required instances that come from the `barbies` package.
@@ -349,19 +351,22 @@ data ConfigB f = ConfigB
     _cServiceB :: ServiceConfigB f,
     _cDirB :: f String
   }
-  deriving (Generic, B.FunctorB, B.TraversableB, B.ApplicativeB)
+  deriving stock Generic
+  deriving anyclass (B.FunctorB, B.TraversableB, B.ApplicativeB)
 
 data DbConfigB f = DbConfigB
   { _dcHostB :: f String,
     _dcPortB :: f Int
   }
-  deriving (Generic, B.FunctorB, B.TraversableB, B.ApplicativeB)
+  deriving stock Generic
+  deriving anyclass (B.FunctorB, B.TraversableB, B.ApplicativeB)
 
 data ServiceConfigB f = ServiceConfigB
   { _scPortB :: f Int,
     _scLogB :: f Bool
   }
-  deriving (Generic, B.FunctorB, B.TraversableB, B.ApplicativeB)
+  deriving stock Generic
+  deriving anyclass (B.FunctorB, B.TraversableB, B.ApplicativeB)
 ```
 
 To define the option parser, we need option parsers for every type inside it.
@@ -412,7 +417,8 @@ data ConfigH f = ConfigH
     _cServiceH :: HKD ServiceConfig f,
     _cDirH :: f String
   }
-  deriving (Generic, B.FunctorB, B.TraversableB, B.ApplicativeB)
+  deriving stock Generic
+  deriving anyclass (B.FunctorB, B.TraversableB, B.ApplicativeB)
 
 configOpt2 :: ConfigH Opt
 configOpt2 =


### PR DESCRIPTION
Hi again @alexpeits 

Here's a small syntactic suggestion to the docs. (BTW the doc-test is absolutely gorgeous!)

What this tries to achieve, is to warn of a nasty pitfall — jcpetruzza/barbies#53 — by means of a reminder to enable `DeriveAnyClass`.

I know, it's written in the .lhs header, how embarrassing of me to not notice; disregarding the hindsight, that's all too easy to miss when you're in the middle of the guide, following along. I was writing a custom `Source`:

```haskell
newtype EnvFileSource f = EnvFileSource (f Harg.ConfigFile)
  deriving stock Generic
  deriving (FunctorB, TraversableB, ApplicativeB)
```

— and got hit with a sudden bizarre error:

> • Can't make a derived instance of ‘FunctorB EnvFileSource’
>     (even with cunning GeneralizedNewtypeDeriving):
>     **cannot eta-reduce the representation type enough**
> • In the newtype declaration for ‘EnvFileSource’

-----------------------------

*(a few hours later)*

-----------------------------

So yeah, in hindsight I know, my fault was forgetting to enable `DeriveAnyClass`. But consider this:

```haskell
newtype EnvFileSource f = EnvFileSource (f Harg.ConfigFile)
  deriving stock Generic
  deriving anyclass (FunctorB, TraversableB, ApplicativeB)
```

→ same noob mistake → much more tractable error message:

> • Can't make a derived instance of
>     ‘FunctorB EnvFileSource’ with the anyclass strategy:
> • In the newtype declaration for ‘EnvFileSource’
> • **Perhaps you intended to use DeriveAnyClass**

Better, eh?

-------------------------------------

I tested this (on top of #79), the doctest still runs OK, `stack test --flag harg:builddocstest` compiles & passes.